### PR TITLE
Add migration notice to Codeberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple, privacy-focused bodyweight training tracker for Android.
 </p>
 
 <p align="center">
-  <a href="https://github.com/Gonbei774/CalisthenicsMemory/releases/latest">Download APK from GitHub Releases</a>
+  <a href="https://codeberg.org/Gonbei774/CalisthenicsMemory/releases/latest">Download APK from Codeberg Releases</a>
 </p>
 
 ---
@@ -58,7 +58,7 @@ The app operates completely offline—no internet connection required, no ads, n
 ## Building
 
 ```bash
-git clone https://github.com/Gonbei774/CalisthenicsMemory.git
+git clone https://codeberg.org/Gonbei774/CalisthenicsMemory.git
 cd CalisthenicsMemory
 ./gradlew assembleDebug
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ A simple, privacy-focused bodyweight training tracker for Android.
   </a>
 </p>
 
-<p align="center">
-  <a href="https://codeberg.org/Gonbei774/CalisthenicsMemory/releases/latest">Download APK from Codeberg Releases</a>
-</p>
-
 ---
 
 ## About

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A simple, privacy-focused bodyweight training tracker for Android.
 
 ---
 
+> **Note**: This repository has migrated to [Codeberg](https://codeberg.org/Gonbei774/CalisthenicsMemory).
+> This GitHub repository is maintained as a read-only mirror.
+
+---
+
 ## About
 
 Calisthenics Memory helps you track and manage bodyweight exercises like push-ups, pull-ups, and squats. Create custom exercises, organize them into progressive levels, and monitor your progress over time.


### PR DESCRIPTION
This adds a note at the top of README.md informing users that the repository has migrated to Codeberg, as requested by F-Droid maintainer @licaon-kter.